### PR TITLE
Allow Motion's %$ Conversion Specifier

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -859,10 +859,10 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
     deviceNameFailMessage = _(
         'Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space'
     )
-    filenameValidRegExp = '^([A-Za-z0-9 ()/._-]|%[CYmdHMSqv])+$'
+    filenameValidRegExp = '^([A-Za-z0-9 ()/._-]|%[CYmdHMSqv$])+$'
     filenameFailMessage = _(
         'File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., '
-        'underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v'
+        'underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v %$'
     )
     dirnameValidRegExp = '^[A-Za-z0-9 ()/._-]+$'
     dirnameFailMessage = _(

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -39,9 +39,10 @@ from motioneye import config, settings, uploadservices, utils
 from motioneye.utils.dtconv import pretty_date_time
 
 _PICTURE_EXTS = ['.jpg']
-_MOVIE_EXTS = ['.avi', '.mp4', '.mov', '.swf', '.flv', '.mkv']
+_MOVIE_EXTS = ['.avi', '.mp4', '.mov', '.swf', '.flv', '.mkv', '.mpg']
 
 FFMPEG_CODEC_MAPPING = {
+    'mpg': 'mpeg1video',
     'mpeg4': 'mpeg4',
     'msmpeg4': 'msmpeg4v2',
     'swf': 'flv1',
@@ -57,6 +58,7 @@ FFMPEG_CODEC_MAPPING = {
 }
 
 FFMPEG_FORMAT_MAPPING = {
+    'mpeg1video': 'mpg',
     'mpeg4': 'avi',
     'msmpeg4': 'avi',
     'swf': 'swf',
@@ -72,6 +74,7 @@ FFMPEG_FORMAT_MAPPING = {
 }
 
 FFMPEG_EXT_MAPPING = {
+    'mpeg1video': 'mpg',
     'mpeg4': 'avi',
     'msmpeg4': 'avi',
     'swf': 'swf',
@@ -87,6 +90,7 @@ FFMPEG_EXT_MAPPING = {
 }
 
 MOVIE_EXT_TYPE_MAPPING = {
+    'mpg': 'video/mpeg',
     'avi': 'video/x-msvideo',
     'mp4': 'video/mp4',
     'mov': 'video/quicktime',

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -39,10 +39,9 @@ from motioneye import config, settings, uploadservices, utils
 from motioneye.utils.dtconv import pretty_date_time
 
 _PICTURE_EXTS = ['.jpg']
-_MOVIE_EXTS = ['.avi', '.mp4', '.mov', '.swf', '.flv', '.mkv', '.mpg']
+_MOVIE_EXTS = ['.avi', '.mp4', '.mov', '.swf', '.flv', '.mkv']
 
 FFMPEG_CODEC_MAPPING = {
-    'mpg': 'mpeg1video',
     'mpeg4': 'mpeg4',
     'msmpeg4': 'msmpeg4v2',
     'swf': 'flv1',
@@ -58,7 +57,6 @@ FFMPEG_CODEC_MAPPING = {
 }
 
 FFMPEG_FORMAT_MAPPING = {
-    'mpeg1video': 'mpg',
     'mpeg4': 'avi',
     'msmpeg4': 'avi',
     'swf': 'swf',
@@ -74,7 +72,6 @@ FFMPEG_FORMAT_MAPPING = {
 }
 
 FFMPEG_EXT_MAPPING = {
-    'mpeg1video': 'mpg',
     'mpeg4': 'avi',
     'msmpeg4': 'avi',
     'swf': 'swf',
@@ -90,7 +87,6 @@ FFMPEG_EXT_MAPPING = {
 }
 
 MOVIE_EXT_TYPE_MAPPING = {
-    'mpg': 'video/mpeg',
     'avi': 'video/x-msvideo',
     'mp4': 'video/mp4',
     'mov': 'video/quicktime',

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -22,7 +22,7 @@ var signatureRegExp = new RegExp('[^A-Za-z0-9/?_.=&{}\\[\\]":, -]', 'g');
 // regex definitions for input sanity checks in frontend
 // they must match the ones in motioneye/config.py
 var deviceNameValidRegExp = new RegExp('^[A-Za-z0-9\-\_\+\ ]+$');
-var filenameValidRegExp = new RegExp('^([A-Za-z0-9 \(\)/._-]|%[CYmdHMSqv])+$');
+var filenameValidRegExp = new RegExp('^([A-Za-z0-9 \(\)/._-]|%[CYmdHMSqv$])+$');
 var dirnameValidRegExp = new RegExp('^[A-Za-z0-9 \(\)/._-]+$');
 var emailValidRegExp = new RegExp('^[A-Za-z0-9 _+.@^~<>,-]+$');
 var webHookUrlValidRegExp = new RegExp('^[^;\']+$');


### PR DESCRIPTION
This PR fixes #2 by allowing the $ character in the filename RegExp checker. Now the camera names can be inserted in motion via the %$ conversion specifier.